### PR TITLE
Fix BLE connection callbacks

### DIFF
--- a/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
@@ -596,6 +596,7 @@ public abstract class HidPeripheral {
                             bluetoothDevicesMap.put(device.getAddress(), device);
                         }
                     }
+                    onDeviceConnected(device);
                     break;
 
                 case BluetoothProfile.STATE_DISCONNECTED:
@@ -615,6 +616,7 @@ public abstract class HidPeripheral {
                     synchronized (bluetoothDevicesMap) {
                         bluetoothDevicesMap.remove(deviceAddress);
                     }
+                    onDeviceDisconnected(device);
                     break;
 
                 default:
@@ -806,5 +808,23 @@ public abstract class HidPeripheral {
         } else {
             serialNumber = newSerialNumber;
         }
+    }
+
+    /**
+     * Called when a central device is connected. Subclasses may override.
+     *
+     * @param device the connected device
+     */
+    protected void onDeviceConnected(@NonNull BluetoothDevice device) {
+        // default no-op
+    }
+
+    /**
+     * Called when a central device is disconnected. Subclasses may override.
+     *
+     * @param device the disconnected device
+     */
+    protected void onDeviceDisconnected(@NonNull BluetoothDevice device) {
+        // default no-op
     }
 }

--- a/blehid-lib/src/main/java/jp/kshoji/blehid/KeyboardPeripheral.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/KeyboardPeripheral.java
@@ -20,13 +20,15 @@ public final class KeyboardPeripheral extends HidPeripheral {
         this.keyboardConnectionCallback = callback;
     }
 
-    public void handleDeviceConnected(BluetoothDevice device) {
+    @Override
+    protected void onDeviceConnected(BluetoothDevice device) {
         if (keyboardConnectionCallback != null) {
             keyboardConnectionCallback.onKeyboardConnected(device);
         }
     }
 
-    public void handleDeviceDisconnected(BluetoothDevice device) {
+    @Override
+    protected void onDeviceDisconnected(BluetoothDevice device) {
         if (keyboardConnectionCallback != null) {
             keyboardConnectionCallback.onKeyboardDisconnected(device);
         }


### PR DESCRIPTION
## Summary
- ensure connection callbacks in `HidPeripheral` are invoked
- override the new callbacks in `KeyboardPeripheral`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_685792cbf2f08320952a0f6ce3554278