### PR TITLE
Delay HID init until permissions granted

### DIFF
--- a/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 class BleViewModel(app: Application) : AndroidViewModel(app) {
     private val context = app.applicationContext
     private val hidManager = HidPeripheralManager(context)
+    private var initialized = false
     private var scanner: BluetoothLeScanner? = null
     private val discoveredDevices = mutableSetOf<BluetoothDevice>()
     private val scanCallback = object : ScanCallback() {
@@ -32,7 +33,9 @@ class BleViewModel(app: Application) : AndroidViewModel(app) {
     private val _nearbyDevices = MutableLiveData<List<BluetoothDevice>>(emptyList())
     val nearbyDevices: LiveData<List<BluetoothDevice>> = _nearbyDevices
 
-    init {
+    fun initialize() {
+        if (initialized) return
+        initialized = true
         hidManager.initialize { device: BluetoothDevice?, connected: Boolean ->
             _connectedDeviceName.postValue(
                 if (connected) "Connected: ${device?.name ?: "Unknown"}"
@@ -68,6 +71,8 @@ class BleViewModel(app: Application) : AndroidViewModel(app) {
     override fun onCleared() {
         super.onCleared()
         scanner?.stopScan(scanCallback)
-        hidManager.stopAdvertising()
+        if (initialized) {
+            hidManager.stopAdvertising()
+        }
     }
 }

--- a/app/src/main/java/com/example/bluetoothkeyboard/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/MainActivity.kt
@@ -21,7 +21,14 @@ class MainActivity : ComponentActivity() {
 
     private val viewModel: BleViewModel by viewModels()
     private val permissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { }
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+            val granted = results.all { it.value }
+            if (granted) {
+                viewModel.initialize()
+            } else {
+                Toast.makeText(this, "Bluetooth permissions denied", Toast.LENGTH_LONG).show()
+            }
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -56,7 +63,12 @@ class MainActivity : ComponentActivity() {
             Manifest.permission.BLUETOOTH_ADVERTISE,
             Manifest.permission.ACCESS_FINE_LOCATION
         )
-        permissionLauncher.launch(permissions)
+        val allGranted = permissions.all { checkSelfPermission(it) == PackageManager.PERMISSION_GRANTED }
+        if (allGranted) {
+            viewModel.initialize()
+        } else {
+            permissionLauncher.launch(permissions)
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- initialize HID functionality only after runtime permissions are granted
- show error toast when permissions denied
- start advertising once permissions are confirmed

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68579649f7288320af5f4e3c13855edc