### PR TITLE
Drop privileged Bluetooth permission

### DIFF
--- a/blehid-lib/src/main/AndroidManifest.xml
+++ b/blehid-lib/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
 </manifest>

--- a/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
@@ -26,6 +26,8 @@ import android.os.ParcelUuid;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.Log;
+import android.content.pm.PackageManager;
+import androidx.core.content.ContextCompat;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -577,10 +579,12 @@ public abstract class HidPeripheral {
                         }, new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED));
 
                         // create bond
-                        try {
-                            device.setPairingConfirmation(true);
-                        } catch (final SecurityException e) {
-                            Log.d(TAG, e.getMessage(), e);
+                        if (ContextCompat.checkSelfPermission(context, "android.permission.BLUETOOTH_PRIVILEGED") == PackageManager.PERMISSION_GRANTED) {
+                            try {
+                                device.setPairingConfirmation(true);
+                            } catch (final SecurityException e) {
+                                Log.d(TAG, e.getMessage(), e);
+                            }
                         }
                         device.createBond();
                     } else if (device.getBondState() == BluetoothDevice.BOND_BONDED) {


### PR DESCRIPTION
## Summary
- remove `BLUETOOTH_PRIVILEGED` from library manifest
- guard `setPairingConfirmation` with runtime permission check

## Testing
- `./gradlew assembleDebug` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_685798eaa9248320bf34d5a7791f52b7