### PR TITLE
Comment out duplicate advertising call

### DIFF
--- a/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
@@ -42,7 +42,8 @@ class BleViewModel(app: Application) : AndroidViewModel(app) {
                 else "Not connected"
             )
         }
-        hidManager.startAdvertising()
+        // Advertising is started inside HidPeripheralManager.initialize()
+        // hidManager.startAdvertising()
     }
 
     fun sendTextAsKeyboard(text: String, delayMs: Long) {


### PR DESCRIPTION
## Summary
- comment out redundant call to `startAdvertising` in `BleViewModel.initialize`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_685798f744e48320816e01653973a7fb