### PR TITLE
Fix permission check for bluetooth bonding

### DIFF
--- a/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/HidPeripheral.java
@@ -579,7 +579,7 @@ public abstract class HidPeripheral {
                         }, new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED));
 
                         // create bond
-                        if (ContextCompat.checkSelfPermission(context, "android.permission.BLUETOOTH_PRIVILEGED") == PackageManager.PERMISSION_GRANTED) {
+                        if (ContextCompat.checkSelfPermission(applicationContext, "android.permission.BLUETOOTH_PRIVILEGED") == PackageManager.PERMISSION_GRANTED) {
                             try {
                                 device.setPairingConfirmation(true);
                             } catch (final SecurityException e) {


### PR DESCRIPTION
## Summary
- fix permission check in `HidPeripheral` during bonding

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68579b1001b48320a4f2915aadf1ea23