### PR TITLE
Fix BLE utility javadoc wording

### DIFF
--- a/blehid-lib/src/main/java/jp/kshoji/blehid/util/BleUtils.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/util/BleUtils.java
@@ -18,7 +18,7 @@ import androidx.annotation.NonNull;
 public class BleUtils {
 
     /**
-     * Check if Bluetooth LE device supported on the running environment.
+     * Check if Bluetooth LE device is supported on the running environment.
      *
      * @param context the context
      * @return true if supported


### PR DESCRIPTION
## Summary
- tweak BleUtils documentation to use proper grammar

## Testing
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_b_6857a1006a6c83278f4b4be38820ad10