### PR TITLE
Update joystick button report map comment

### DIFF
--- a/blehid-lib/src/main/java/jp/kshoji/blehid/JoystickPeripheral.java
+++ b/blehid-lib/src/main/java/jp/kshoji/blehid/JoystickPeripheral.java
@@ -21,7 +21,7 @@ public class JoystickPeripheral extends HidPeripheral {
             USAGE_MAXIMUM(1),   0x03,
             LOGICAL_MINIMUM(1), 0x00,
             LOGICAL_MAXIMUM(1), 0x01,
-            REPORT_COUNT(1),    0x03,         //   2 bits (Buttons)
+            REPORT_COUNT(1),    0x03,         //   3 bits (Buttons)
             REPORT_SIZE(1),     0x01,
             INPUT(1),           0x02,         //   Data, Variable, Absolute
             REPORT_COUNT(1),    0x01,         //   6 bits (Padding)


### PR DESCRIPTION
## Summary
- fix a comment on the joystick report map indicating that 3 bits are used for buttons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857a10ce09c832786b9bda26aebd768