### PR TITLE
Update BLE HID namespace

### DIFF
--- a/blehid-lib/build.gradle
+++ b/blehid-lib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.kshoji.blehid' // ✅ Add this line
+    namespace 'jp.kshoji.blehid'
 
     compileSdkVersion 35
 


### PR DESCRIPTION
## Summary
- use `jp.kshoji.blehid` as the blehid library namespace

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857a10824b88327a84e735b12fcce1e