### PR TITLE
Add retry logic and permission checks

### DIFF
--- a/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/BleViewModel.kt
@@ -7,6 +7,8 @@ import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
 import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -56,6 +58,22 @@ class BleViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun discoverNearbyDevices() {
+        // Verify runtime permission for scanning
+        if (ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.BLUETOOTH_SCAN
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            // location permission is also required for scanning on modern Android versions
+            if (ContextCompat.checkSelfPermission(
+                    context,
+                    android.Manifest.permission.ACCESS_FINE_LOCATION
+                ) != PackageManager.PERMISSION_GRANTED
+            ) {
+                return
+            }
+        }
+
         val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
         scanner = bluetoothManager.adapter.bluetoothLeScanner
         discoveredDevices.clear()

--- a/app/src/main/java/com/example/bluetoothkeyboard/HidPeripheralManager.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/HidPeripheralManager.kt
@@ -2,10 +2,14 @@ package com.example.bluetoothkeyboard
 
 import android.bluetooth.BluetoothDevice
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import jp.kshoji.blehid.KeyboardPeripheral
 
 class HidPeripheralManager(private val context: Context) {
     private var keyboardPeripheral: KeyboardPeripheral? = null
+    private val handler = Handler(Looper.getMainLooper())
 
     fun initialize(onConnectionChanged: (BluetoothDevice?, Boolean) -> Unit) {
         keyboardPeripheral = KeyboardPeripheral(context)
@@ -19,18 +23,28 @@ class HidPeripheralManager(private val context: Context) {
 
             override fun onKeyboardDisconnected(device: BluetoothDevice) {
                 onConnectionChanged(device, false)
+                // restart advertising after a short delay to allow reconnection
+                handler.postDelayed({ startAdvertising() }, 3000)
             }
         })
 
-        keyboardPeripheral?.startAdvertising()
+        startAdvertising()
     }
 
     fun startAdvertising() {
-        keyboardPeripheral?.startAdvertising()
+        try {
+            keyboardPeripheral?.startAdvertising()
+        } catch (e: Exception) {
+            Log.e("HID", "Failed to start advertising", e)
+        }
     }
 
     fun stopAdvertising() {
-        keyboardPeripheral?.stopAdvertising()
+        try {
+            keyboardPeripheral?.stopAdvertising()
+        } catch (e: Exception) {
+            Log.e("HID", "Failed to stop advertising", e)
+        }
     }
 
     fun sendKey(char: Char) {


### PR DESCRIPTION
## Summary
- restart advertising if the keyboard disconnects
- add error handling when starting/stopping advertising
- validate scan permissions before discovering devices

## Testing
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68579f4e225c8327850a1c2a7f6df583