### PR TITLE
Improve Bluetooth enable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The generated APK can be found in `app/build/outputs/apk/debug/`.
 
 1. Install the generated APK on an Android device that supports BLE peripheral mode.
 2. Launch the app and grant the requested Bluetooth permissions.
-3. Enter text and press **Send** to transmit it as keyboard input to the connected device.
-4. Use **Scan Nearby Devices** to discover BLE devices around you.
+3. If prompted, enable Bluetooth so the device can advertise and pair.
+4. Enter text and press **Send** to transmit it as keyboard input to the connected device.
+5. Use **Scan Nearby Devices** to discover BLE devices around you.
 
 This repository also contains `blehid-lib`, a library used by the app to handle BLE HID operations.

--- a/app/src/main/java/com/example/bluetoothkeyboard/MainActivity.kt
+++ b/app/src/main/java/com/example/bluetoothkeyboard/MainActivity.kt
@@ -15,6 +15,7 @@ import android.Manifest
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.content.pm.PackageManager
+import jp.kshoji.blehid.util.BleUtils
 import android.widget.Toast
 
 class MainActivity : ComponentActivity() {
@@ -38,6 +39,10 @@ class MainActivity : ComponentActivity() {
             finish()
         }
 
+        if (!ensureBluetoothEnabled()) {
+            Toast.makeText(this, "Please enable Bluetooth", Toast.LENGTH_LONG).show()
+        }
+
         requestPermissions()
 
         setContent {
@@ -50,10 +55,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun checkBleSupport(): Boolean {
-        val bluetoothManager = getSystemService(BLUETOOTH_SERVICE) as BluetoothManager
-        val bluetoothAdapter = bluetoothManager.adapter
-        return bluetoothAdapter != null && packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE) &&
-                bluetoothAdapter.isMultipleAdvertisementSupported
+        return BleUtils.isBlePeripheralSupported(this)
     }
 
     private fun requestPermissions() {
@@ -68,6 +70,17 @@ class MainActivity : ComponentActivity() {
             viewModel.initialize()
         } else {
             permissionLauncher.launch(permissions)
+        }
+    }
+
+    private fun ensureBluetoothEnabled(): Boolean {
+        val bluetoothManager = getSystemService(BLUETOOTH_SERVICE) as BluetoothManager
+        val adapter = bluetoothManager.adapter ?: return false
+        return if (!adapter.isEnabled) {
+            BleUtils.enableBluetooth(this)
+            false
+        } else {
+            true
         }
     }
 


### PR DESCRIPTION
## Summary
- verify BLE peripheral support using library utility
- prompt users to enable Bluetooth before starting
- document enabling Bluetooth in README

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68579fac2ecc83278dc4875aa9b510a6